### PR TITLE
Cleanup

### DIFF
--- a/scc.py
+++ b/scc.py
@@ -29,59 +29,59 @@ def sep():
 if arg.rand:
 	with open(f"{home}/.scc/ccs/en/{arg.rand}.json") as file:
 		data = json.load(file)
-		key = random.choice(list(data))
-		sep()
-		print(key)
-		sep()
-		for k, v in data[key].items():
-			if k == "Attribute(s)":
-				break
-			print(f"\033[4;33m{k}\033[0m :{v}")
+	key = random.choice(list(data))
+	sep()
+	print(key)
+	sep()
+	for k, v in data[key].items():
+		if k == "Attribute(s)":
+			break
+		print(f"\033[4;33m{k}\033[0m :{v}")
 
 
 # html part
 if not arg.html:
 	with open(f"{home}/.scc/ccs/en/html.json") as file:
 		data = json.load(file)
-		if arg.export == "html":
-			print("exporting to html ...")
-			html_output = '<html><head><title>SCC-HTML CHEAT CHEET</title></head><body><style>body{ max-width:100vw ; font-family:"roboto","open sans" , "ubuntu" ,"sans-serif";background-color:#fff;color:#666; }#tag{font-size:1.2em ; color:#006688 ; background-color:#ddd ;display:inline-block ;  border-radius:10px ; padding:0.7em ;  } .xmp_tags{ padding:10px ;border-radius:5px ;word-wrap: break-word;font-family:monospace } .xmp_tags:first-child()::before{ content: "Tag : " ;}#wrapper{background-color:#eee;padding:1em ;border-radius:10px ; margin:0.5em auto ; max-width:95vw ;word-wrap: break-word; overflow:auto ; }h1{text-align:center; }</style><h1>SCC - HTML Cheat Cheet</h1>'
-			key_elem = ""
-			for tag in data:
-				key_elem += f"<div id='wrapper'><span id='tag'>{tag}</span>"
-				for desc in data[tag]:
-					if desc == list(data[tag])[0]:
-						continue
-					if desc == "Attribute(s)":
-						key_elem += "--- Attributes ---"
-						attrs = data[tag][desc]
-						for attr in attrs:
-							key_elem += f"<xmp class='xmp_tags'>{attr}:{data[tag][desc][attr]}</xmp>"
-						continue
-					key_elem += f"<xmp class='xmp_tags'>{data[tag][desc]}</xmp>"
-				key_elem += "</div>"
-			html_output += key_elem
+	if arg.export == "html":
+		print("exporting to html ...")
+		html_output = '<html><head><title>SCC-HTML CHEAT CHEET</title></head><body><style>body{ max-width:100vw ; font-family:"roboto","open sans" , "ubuntu" ,"sans-serif";background-color:#fff;color:#666; }#tag{font-size:1.2em ; color:#006688 ; background-color:#ddd ;display:inline-block ;  border-radius:10px ; padding:0.7em ;  } .xmp_tags{ padding:10px ;border-radius:5px ;word-wrap: break-word;font-family:monospace } .xmp_tags:first-child()::before{ content: "Tag : " ;}#wrapper{background-color:#eee;padding:1em ;border-radius:10px ; margin:0.5em auto ; max-width:95vw ;word-wrap: break-word; overflow:auto ; }h1{text-align:center; }</style><h1>SCC - HTML Cheat Cheet</h1>'
+		key_elem = ""
+		for tag in data:
+			key_elem += f"<div id='wrapper'><span id='tag'>{tag}</span>"
+			for desc in data[tag]:
+				if desc == list(data[tag])[0]:
+					continue
+				if desc == "Attribute(s)":
+					key_elem += "--- Attributes ---"
+					attrs = data[tag][desc]
+					for attr in attrs:
+						key_elem += f"<xmp class='xmp_tags'>{attr}:{data[tag][desc][attr]}</xmp>"
+					continue
+				key_elem += f"<xmp class='xmp_tags'>{data[tag][desc]}</xmp>"
+			key_elem += "</div>"
+		html_output += key_elem
 
-			with open("exported-scc.html", "w") as file:
-				file.write(html_output)
-			webbrowser.open_new_tab("exported-scc.html")
-			print("Done.")
-			exit()
-		print("\n".join(data))
+		with open("exported-scc.html", "w") as file:
+			file.write(html_output)
+		webbrowser.open_new_tab("exported-scc.html")
+		print("Done.")
+		exit()
+	print("\n".join(data))
 elif arg.html != "scc_empty":
 	try:
 		with open(f"{home}/.scc/ccs/en/html.json") as file:
 			data = json.load(file)
-			for key, val in data[arg.html.rstrip()].items():
-				if key == "Attribute(s)":
-					sep()
-					print("--- Attributes ---".rjust(40))
-					sep()
-					for elem, info in val.items():
-						print(f"\033[4;33m• {elem}\u001b[0m : {info}")
-					sep()
-					exit()
-				print(f"\033[4;33m{key}\u001b[0m : {val}")
+		for key, val in data[arg.html.rstrip()].items():
+			if key == "Attribute(s)":
+				sep()
+				print("--- Attributes ---".rjust(40))
+				sep()
+				for elem, info in val.items():
+					print(f"\033[4;33m• {elem}\u001b[0m : {info}")
+				sep()
+				exit()
+			print(f"\033[4;33m{key}\u001b[0m : {val}")
 	except KeyError:
 		print("This HTML tag doesn't exist")
 
@@ -89,13 +89,13 @@ elif arg.html != "scc_empty":
 if not arg.css:
 	with open(f"{home}/.scc/ccs/en/css.json") as file:
 		data = json.load(file)
-		print("\n".join(data))
+	print("\n".join(data))
 elif arg.css != "scc_empty":
 	try:
 		with open(f"{home}/.scc/ccs/en/css.json") as file:
 			data = json.load(file)
-			for key, val in data[arg.css.rstrip()].items():
-				print(f"\033[4;33m{key}\033[0m :{val}")
+		for key, val in data[arg.css.rstrip()].items():
+			print(f"\033[4;33m{key}\033[0m :{val}")
 	except KeyError:
 		print("The CSS property that you requested doesn't exist/isn't indexed")
 
@@ -104,13 +104,13 @@ elif arg.css != "scc_empty":
 if not arg.js:
 	with open(f"{home}/.scc/ccs/en/js.json") as file:
 		data = json.load(file)
-		print("\n".join(data))
+	print("\n".join(data))
 elif arg.js != "scc_empty":
 	try:
 		with open(f"{home}/.scc/ccs/en/js.json") as file:
 			data = json.load(file)
-			for key, val in data[arg.js.rstrip()].items():
-				print(f"\033[4;33m{key}\033[0m : {val}")
+		for key, val in data[arg.js.rstrip()].items():
+			print(f"\033[4;33m{key}\033[0m : {val}")
 	except KeyError:
 		print(f"'{arg.js}' Not found")
 		try:

--- a/scc.py
+++ b/scc.py
@@ -1,30 +1,33 @@
 #!/usr/bin/env python3
 
-import os 
-import argparse 
-import json 
-import webbrowser 
-import random 
+import argparse
+import json
+import os
+import random
+import webbrowser
+
+
 home = os.path.expanduser("~")
-parser = argparse.ArgumentParser(description="SCC - Commandline Cheat Sheet") 
-parser.add_argument('--export',choices=["html"],default=None)
+parser = argparse.ArgumentParser(description="SCC - Commandline Cheat Sheet")
+parser.add_argument('--export', choices=["html"], default=None)
 group = parser.add_mutually_exclusive_group()
 
-argument_list = ['-html','-css','-js','-python']
+argument_list = ['-html', '-css', '-js', '-python']
 
 for i in argument_list:
-	group.add_argument(i,nargs='?',default='scc_empty')
+	group.add_argument(i, nargs='?', default='scc_empty')
 
-parser.add_argument('-rand',choices=["html","css","js"])
-arg = parser.parse_args() 
+parser.add_argument('-rand', choices=["html", "css", "js"])
+arg = parser.parse_args()
+
 
 def sep():
 	print('\u001b[33;1m-\u001b[0m'*60)
 
 
-# random 
-if arg.rand != None:
-	with open(f"{home}/.scc/ccs/en/{arg.rand}.json") as file :
+# random
+if not arg.rand:
+	with open(f"{home}/.scc/ccs/en/{arg.rand}.json") as file:
 		data = json.load(file)
 		key = random.choice(list(data.keys()))
 		sep()
@@ -32,17 +35,16 @@ if arg.rand != None:
 		sep()
 		for k, v in data[key].items():
 			if k == "Attribute(s)":
-				break 
+				break
 			print(f"\033[4;33m{k}\033[0m :{v}")
 
 
-
-# html part 
+# html part
 if not arg.html:
 	with open(f"{home}/.scc/ccs/en/html.json") as file:
 		data = json.load(file)
-		if arg.export=="html" :
-			print('exporting to html ... ')
+		if arg.export == "html":
+			print('exporting to html ...')
 			html_output = '<html><head><title>SCC-HTML CHEAT CHEET</title></head><body><style>body{ max-width:100vw ; font-family:"roboto","open sans" , "ubuntu" ,"sans-serif";background-color:#fff;color:#666; }#tag{font-size:1.2em ; color:#006688 ; background-color:#ddd ;display:inline-block ;  border-radius:10px ; padding:0.7em ;  } .xmp_tags{ padding:10px ;border-radius:5px ;word-wrap: break-word;font-family:monospace } .xmp_tags:first-child()::before{ content: "Tag : " ;}#wrapper{background-color:#eee;padding:1em ;border-radius:10px ; margin:0.5em auto ; max-width:95vw ;word-wrap: break-word; overflow:auto ; }h1{text-align:center; }</style><h1>SCC - HTML Cheat Cheet</h1>'
 			key_elem = ""
 			for tag in data:
@@ -51,16 +53,16 @@ if not arg.html:
 					if desc == list(data[tag])[0]:
 						continue
 					if desc == "Attribute(s)":
-						key_elem+= "--- Attributes ---"
+						key_elem += "--- Attributes ---"
 						attrs = data[tag][desc]
 						for attr in attrs:
-							key_elem+= f"<xmp class='xmp_tags'>{attr}:{data[tag][desc][attr]}</xmp>"
+							key_elem += f"<xmp class='xmp_tags'>{attr}:{data[tag][desc][attr]}</xmp>"
 						continue
 					key_elem += f"<xmp class='xmp_tags'>{data[tag][desc]}</xmp>"
-				key_elem += "</div>"	
-			html_output += key_elem 
+				key_elem += "</div>"
+			html_output += key_elem
 
-			with open("exported-scc.html",'w') as file:
+			with open("exported-scc.html", 'w') as file:
 				file.write(f'{html_output}')
 			webbrowser.open_new_tab("exported-scc.html")
 			print('Done.')
@@ -74,11 +76,11 @@ elif arg.html != "scc_empty":
 				if key == "Attribute(s)":
 					sep()
 					print("--- Attributes ---".rjust(40))
-					sep() 
+					sep()
 					for elem, info in val.items():
 						print(f'\033[4;33m• {elem}\u001b[0m : {info}')
 					sep()
-					exit()	
+					exit()
 				print(f'\033[4;33m{key}\u001b[0m : {val}')
 	except KeyError:
 		print("this tag doesnt exist")
@@ -96,7 +98,7 @@ elif arg.css != 'scc_empty':
 			for key, val in data[arg.css.rstrip()].items():
 				print(f"\033[4;33m{key}\033[0m :{val}")
 	except KeyError:
-		print("The CSS proprety that you requested doesn't exist/isnt't indexed ")
+		print("The CSS proprety that you requested doesn't exist/isnt't indexed")
 
 
 # js
@@ -112,13 +114,13 @@ elif arg.js != 'scc_empty':
 				print(f"\033[4;33m{key}\033[0m : {val}")
 	except KeyError:
 		print(f"'{arg.js}' Not found")
-		try : 
+		try:
 			lkeys = []
 			for key in data:
 				if arg.js.split('.')[0] == key.split('.')[0]:
 					lkeys.append(key)
 			if lkeys:
-				print("possible values : ")
+				print("possible values :")
 				print("\n".join(lkeys))
-		except Exception :
-			pass 
+		except Exception:
+			pass

--- a/scc.py
+++ b/scc.py
@@ -9,27 +9,27 @@ import webbrowser
 
 home = os.path.expanduser("~")
 parser = argparse.ArgumentParser(description="SCC - Commandline Cheat Sheet")
-parser.add_argument('--export', choices=["html"], default=None)
+parser.add_argument("--export", choices=["html"], default=None)
 group = parser.add_mutually_exclusive_group()
 
-argument_list = ['-html', '-css', '-js', '-python']
+argument_list = ["-html", "-css", "-js", "-python"]
 
 for i in argument_list:
-	group.add_argument(i, nargs='?', default='scc_empty')
+	group.add_argument(i, nargs="?", default="scc_empty")
 
-parser.add_argument('-rand', choices=["html", "css", "js"])
+parser.add_argument("-rand", choices=["html", "css", "js"])
 arg = parser.parse_args()
 
 
 def sep():
-	print('\u001b[33;1m-\u001b[0m'*60)
+	print("\u001b[33;1m-\u001b[0m" * 60)
 
 
 # random
-if not arg.rand:
+if arg.rand:
 	with open(f"{home}/.scc/ccs/en/{arg.rand}.json") as file:
 		data = json.load(file)
-		key = random.choice(list(data.keys()))
+		key = random.choice(list(data))
 		sep()
 		print(key)
 		sep()
@@ -44,7 +44,7 @@ if not arg.html:
 	with open(f"{home}/.scc/ccs/en/html.json") as file:
 		data = json.load(file)
 		if arg.export == "html":
-			print('exporting to html ...')
+			print("exporting to html ...")
 			html_output = '<html><head><title>SCC-HTML CHEAT CHEET</title></head><body><style>body{ max-width:100vw ; font-family:"roboto","open sans" , "ubuntu" ,"sans-serif";background-color:#fff;color:#666; }#tag{font-size:1.2em ; color:#006688 ; background-color:#ddd ;display:inline-block ;  border-radius:10px ; padding:0.7em ;  } .xmp_tags{ padding:10px ;border-radius:5px ;word-wrap: break-word;font-family:monospace } .xmp_tags:first-child()::before{ content: "Tag : " ;}#wrapper{background-color:#eee;padding:1em ;border-radius:10px ; margin:0.5em auto ; max-width:95vw ;word-wrap: break-word; overflow:auto ; }h1{text-align:center; }</style><h1>SCC - HTML Cheat Cheet</h1>'
 			key_elem = ""
 			for tag in data:
@@ -62,10 +62,10 @@ if not arg.html:
 				key_elem += "</div>"
 			html_output += key_elem
 
-			with open("exported-scc.html", 'w') as file:
-				file.write(f'{html_output}')
+			with open("exported-scc.html", "w") as file:
+				file.write(html_output)
 			webbrowser.open_new_tab("exported-scc.html")
-			print('Done.')
+			print("Done.")
 			exit()
 		print("\n".join(data))
 elif arg.html != "scc_empty":
@@ -78,27 +78,26 @@ elif arg.html != "scc_empty":
 					print("--- Attributes ---".rjust(40))
 					sep()
 					for elem, info in val.items():
-						print(f'\033[4;33m• {elem}\u001b[0m : {info}')
+						print(f"\033[4;33m• {elem}\u001b[0m : {info}")
 					sep()
 					exit()
-				print(f'\033[4;33m{key}\u001b[0m : {val}')
+				print(f"\033[4;33m{key}\u001b[0m : {val}")
 	except KeyError:
-		print("this tag doesnt exist")
+		print("This HTML tag doesn't exist")
 
 # css part
 if not arg.css:
-
 	with open(f"{home}/.scc/ccs/en/css.json") as file:
 		data = json.load(file)
 		print("\n".join(data))
-elif arg.css != 'scc_empty':
+elif arg.css != "scc_empty":
 	try:
 		with open(f"{home}/.scc/ccs/en/css.json") as file:
 			data = json.load(file)
 			for key, val in data[arg.css.rstrip()].items():
 				print(f"\033[4;33m{key}\033[0m :{val}")
 	except KeyError:
-		print("The CSS proprety that you requested doesn't exist/isnt't indexed")
+		print("The CSS property that you requested doesn't exist/isn't indexed")
 
 
 # js
@@ -106,7 +105,7 @@ if not arg.js:
 	with open(f"{home}/.scc/ccs/en/js.json") as file:
 		data = json.load(file)
 		print("\n".join(data))
-elif arg.js != 'scc_empty':
+elif arg.js != "scc_empty":
 	try:
 		with open(f"{home}/.scc/ccs/en/js.json") as file:
 			data = json.load(file)
@@ -117,7 +116,7 @@ elif arg.js != 'scc_empty':
 		try:
 			lkeys = []
 			for key in data:
-				if arg.js.split('.')[0] == key.split('.')[0]:
+				if arg.js.split(".")[0] == key.split(".")[0]:
 					lkeys.append(key)
 			if lkeys:
 				print("possible values :")

--- a/scc.py
+++ b/scc.py
@@ -47,18 +47,17 @@ if not arg.html:
 		print("exporting to html ...")
 		html_output = '<html><head><title>SCC-HTML CHEAT CHEET</title></head><body><style>body{ max-width:100vw ; font-family:"roboto","open sans" , "ubuntu" ,"sans-serif";background-color:#fff;color:#666; }#tag{font-size:1.2em ; color:#006688 ; background-color:#ddd ;display:inline-block ;  border-radius:10px ; padding:0.7em ;  } .xmp_tags{ padding:10px ;border-radius:5px ;word-wrap: break-word;font-family:monospace } .xmp_tags:first-child()::before{ content: "Tag : " ;}#wrapper{background-color:#eee;padding:1em ;border-radius:10px ; margin:0.5em auto ; max-width:95vw ;word-wrap: break-word; overflow:auto ; }h1{text-align:center; }</style><h1>SCC - HTML Cheat Cheet</h1>'
 		key_elem = ""
-		for tag in data:
+		for tag, tag_val in data.items():
 			key_elem += f"<div id='wrapper'><span id='tag'>{tag}</span>"
-			for desc in data[tag]:
-				if desc == list(data[tag])[0]:
+			for desc, desc_val in tag_val.items():
+				if desc == list(tag_val)[0]:
 					continue
 				if desc == "Attribute(s)":
 					key_elem += "--- Attributes ---"
-					attrs = data[tag][desc]
-					for attr in attrs:
-						key_elem += f"<xmp class='xmp_tags'>{attr}:{data[tag][desc][attr]}</xmp>"
+					for attr, attr_val in desc_val.items():
+						key_elem += f"<xmp class='xmp_tags'>{attr}:{attr_val}</xmp>"
 					continue
-				key_elem += f"<xmp class='xmp_tags'>{data[tag][desc]}</xmp>"
+				key_elem += f"<xmp class='xmp_tags'>{desc_val}</xmp>"
 			key_elem += "</div>"
 		html_output += key_elem
 


### PR DESCRIPTION
This pull request does a few minor things to improve readability and consistency.
- Follows pylint and flake8 standards for:
    - Stripping trailing whitespace
    - Having a space follow commas when passing parameters
    - Sorted imports
- More consistent use of " for surrounding strings
- Reduced nesting by moving code out of the `with` block when possible
- Restructuring more of the for-loops to use `.items()` to access `val`s from `dict`s
- Small other bits of cleanup